### PR TITLE
Maintenance: upgrade rclone baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.8 as base
+FROM alpine:3.9 as base
 
 FROM base as builder
-ARG VERSION
+ARG VERSION=v1.45
 
 RUN wget https://github.com/ncw/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
 RUN unzip rclone-$VERSION-linux-amd64.zip
@@ -12,7 +12,7 @@ RUN cd rclone-*-linux-amd64 && \
 
 FROM base
 
-RUN apk -U add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk --update --no-cache add ca-certificates inotify-tools
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone
 
 ENTRYPOINT ["/usr/bin/rclone"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.10 as base
+FROM alpine:3.11.3 as base
+
+## build-stage
 
 FROM base as builder
-ARG VERSION=v1.49.1
+ARG VERSION=v1.50.2
 
 RUN wget https://github.com/ncw/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
 RUN unzip rclone-$VERSION-linux-amd64.zip
@@ -10,9 +12,25 @@ RUN cd rclone-*-linux-amd64 && \
     chown root:root /usr/bin/rclone && \
     chmod 755 /usr/bin/rclone
 
+##
+## runtime-stage
+
 FROM base
 
-RUN apk --update --no-cache add ca-certificates inotify-tools lz4 zstd
+ARG VERSION=v1.50.2
+
+## https://github.com/opencontainers/image-spec/releases/tag/v1.0.1
+LABEL org.opencontainers.image.url="https://github.com/travelping/docker-rclone"
+LABEL org.opencontainers.image.source="https://github.com/travelping/docker-rclone"
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.vendor="travelping.com"
+LABEL org.opencontainers.image.title="rclone-$VERSION"
+LABEL org.opencontainers.image.description="rclone - rsync for cloud storage"
+
+RUN apk --update --no-cache add \
+        ca-certificates \
+        inotify-tools \
+        lz4 zstd
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone
 
 ENTRYPOINT ["/usr/bin/rclone"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9 as base
+FROM alpine:3.10 as base
 
 FROM base as builder
 ARG VERSION=v1.45

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cd rclone-*-linux-amd64 && \
 
 FROM base
 
-RUN apk --update --no-cache add ca-certificates inotify-tools lz4
+RUN apk --update --no-cache add ca-certificates inotify-tools lz4 zstd
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone
 
 ENTRYPOINT ["/usr/bin/rclone"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10 as base
 
 FROM base as builder
-ARG VERSION=v1.45
+ARG VERSION=v1.49.1
 
 RUN wget https://github.com/ncw/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
 RUN unzip rclone-$VERSION-linux-amd64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cd rclone-*-linux-amd64 && \
 
 FROM base
 
-RUN apk --update --no-cache add ca-certificates inotify-tools
+RUN apk --update --no-cache add ca-certificates inotify-tools lz4
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone
 
 ENTRYPOINT ["/usr/bin/rclone"]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-[github]: https://github.com/rayou/docker-rclone
-[app-github]: https://github.com/ncw/rclone
-[microbadger]: https://microbadger.com/images/rayou/rclone
-[dockerstore]: https://hub.docker.com/r/rayou/rclone
-[donation]: https://donorbox.org/rayou?amount=10
-
-# docker-rclone
-[![](https://images.microbadger.com/badges/image/rayou/rclone.svg)][microbadger] [![](https://images.microbadger.com/badges/version/rayou/rclone.svg)][microbadger] [![](https://img.shields.io/docker/stars/rayou/rclone.svg)][dockerstore] [![](https://img.shields.io/badge/Donate-Donorbox-green.svg)][donation]
-
-Docker image of [rclone][app-github].
-
-Repository name in Docker Hub: [rayou/rclone][dockerstore]
-
-Repository name in Github: [rayou/docker-rclone][github]
-
 # Build
 ```bash
 $ docker build --build-arg VERSION=$RCLONE_VERSION -t rclone .
@@ -20,32 +5,39 @@ $ docker build --build-arg VERSION=$RCLONE_VERSION -t rclone .
 ```
 
 # Usage
-
-### Run `rclone` directly
+Besides `rclone` this container also features `inotify`.
+### Run `rclone` (default entrypoint)
 ```bash
-$ docker run --rm -it rayou/rclone:latest --help
+$ docker run --rm -it travelping/rclone:latest --help
 ```
 
 ### Run shell
 ```bash
-$ docker run --rm -it --entrypoint=/bin/sh rayou/rclone:latest
+$ docker run --rm -it --entrypoint=/bin/sh travelping/rclone:latest
 ```
 
-# Documentation
-- https://rclone.org/docs/
 
-# Contributing
+## Debugging
+All inotify-events can be neatly logged using this command:
+```
+inotifywait -mr --timefmt '%H:%M' --format '%T %w %e %f' /data/"
+```
 
-PRs are welcome.
+## Script
 
-# Author
+Wating for the `close_write` event, this command only pushes "finished" data to the destination.
+```
+watchnames=''
+[ -d /data/ ] && watchnames="$watchnames /data/"
+inotifywait --monitor -e close_write --format %w%f $watchnames | while read FILE
+do
+  echo "$FILE is finished. Moving to data/finished/"
+  mv $FILE/ data/finished/
+  rclone move /data/finished/ onedrive:data/
+done
+```
 
-Ray Ou - yuhung.ou@live.com
-
-# Donation
-
-[![](https://d1iczxrky3cnb2.cloudfront.net/button-small-green.png)][donation]
-
-# License
-
-MIT.
+Endpoints checked:
+- [x] SFTP
+- [X] Onedrive
+- [ ] S3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To find the name of the environment variable, first, take the long option name,
 strip the leading --, change - to _ make upper case and prepend RCLONE_.
 All available endpoints are described in the [official rclone documentation](https://rclone.org/commands/rclone_move/)
 of each command.
+
 ### Run `rclone` (default entrypoint)
 ```bash
 $ docker run --rm -it travelping/rclone:latest --help
@@ -23,7 +24,21 @@ docker run --rm -it -e RCLONE_CONFIG_SFTP_TYPE=sftp \
 -e RCLONE_CONFIG_SFTP_HOST=host.com \
 -e RCLONE_CONFIG_SFTP_USER=name \
 -e RCLONE_CONFIG_SFTP_PORT=23 \
--e RCLONE_CONFIG_SFTP_PASS=mSZyspHocI375S3V7OupBbljCpqSnhD6 travelping/rclone:v1.0 touch sftp:path
+-e RCLONE_CONFIG_SFTP_PASS=password travelping/rclone:v1.0 touch sftp:path
+```
+
+### Run `rclone` (s3)
+This configuration provides a simple functionality test by enhancing the default entrypoint (`usr/bin/rclone`).
+Running a touch command on the remote path of a s3 bucket can be done entirely through environment.
+
+```bash
+docker run --rm -it -e RCLONE_CONFIG_S3_TYPE: "s3" \
+-e RCLONE_CONFIG_S3_ENV_AUTH: "false" \
+-e RCLONE_CONFIG_S3_ACCESS_KEY_ID: "<sensitive>" \
+-e RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "<sensitive>" \
+-e RCLONE_CONFIG_S3_REGION: "s3-<region>" \
+-e RCLONE_CONFIG_S3_ACL: "private" \
+    RCLONE_CONFIG_S3_FORCE_PATH_STYLE: "false" travelping/rclone:v1.0 touch sftp:path
 ```
 
 ### Run shell
@@ -31,10 +46,10 @@ docker run --rm -it -e RCLONE_CONFIG_SFTP_TYPE=sftp \
 $ docker run --rm -it --entrypoint=/bin/sh travelping/rclone:latest
 ```
 
-## Inotify
+# Inotify
 Besides `rclone` this container also features `inotify`. Watchpatterns can be used to make sure only finished files
-are being transfered.
-All inotify-events can be neatly logged using this command:
+are being transfered. This is important so no garbage-data is moved (e.g. traces still beeing captured).
+All inotify-events for a directory `/data/` can be neatly logged using this command:
 ```
 inotifywait -mr --timefmt '%H:%M' --format '%T %w %e %f' /data/"
 ```
@@ -48,6 +63,11 @@ inotifywait --monitor -e close_write --format %w%f $watchnames | while read FILE
 do
   echo "$FILE is finished. Moving to data/finished/"
   mv $FILE/ data/finished/
-  rclone move /data/finished/ sftp:data/
+  rclone move /data/finished/ $RCLONE_REMOTE_NAME:RCLONE_REMOTE_PATH/
 done
 ```
+
+Endpoints checked:
+- [x] SFTP
+- [X] Onedrive
+- [X] S3

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Build
+
 ```bash
 $ docker build --build-arg VERSION=$RCLONE_VERSION -t rclone .
-# docker build --build-arg VERSION=v1.45 -t rclone .
 ```
 
 # Usage
-`Rclone` is defined generically through the container environment.
-To find the name of the environment variable, first, take the long option name,
-strip the leading --, change - to _ make upper case and prepend RCLONE_.
-All available endpoints are described in the [official rclone documentation](https://rclone.org/commands/rclone_move/)
-of each command.
+
+`Rclone` is defined generically through the container environment.  To find
+the name of the environment variable, first, take the long option name, strip
+the leading --, change - to _ make upper case and prepend RCLONE\_.
+All available endpoints are described in the [official rclone
+documentation](https://rclone.org/commands/rclone_move/) of each command.
 
 ### Run `rclone` (default entrypoint)
 ```bash
@@ -28,8 +29,10 @@ docker run --rm -it -e RCLONE_CONFIG_SFTP_TYPE=sftp \
 ```
 
 ### Run `rclone` (s3)
-This configuration provides a simple functionality test by enhancing the default entrypoint (`usr/bin/rclone`).
-Running a touch command on the remote path of a s3 bucket can be done entirely through environment.
+
+This configuration provides a simple functionality test by enhancing the
+default entrypoint (`usr/bin/rclone`).  Running a touch command on the remote
+path of a s3 bucket can be done entirely through environment.
 
 ```bash
 docker run --rm -it -e RCLONE_CONFIG_S3_TYPE: "s3" \
@@ -47,15 +50,22 @@ $ docker run --rm -it --entrypoint=/bin/sh travelping/rclone:latest
 ```
 
 # Inotify
-Besides `rclone` this container also features `inotify`. Watchpatterns can be used to make sure only finished files
-are being transfered. This is important so no garbage-data is moved (e.g. traces still beeing captured).
-All inotify-events for a directory `/data/` can be neatly logged using this command:
+
+Besides `rclone` this container also features `inotify`. Watchpatterns can be
+used to make sure only finished files are being transfered. This is important
+so no garbage-data is moved (e.g. traces still beeing captured).  All
+inotify-events for a directory `/data/` can be neatly logged using this
+command:
+
 ```
 inotifywait -mr --timefmt '%H:%M' --format '%T %w %e %f' /data/
 ```
 
 ## Inotify-Script
-Wating for the `close_write` event, this command only pushes "finished" data to the destination.
+
+Wating for the `close_write` event, this command only pushes "finished" data
+to the destination.
+
 ```
 watchnames=''
 [ -d /data/ ] && watchnames="$watchnames /data/"
@@ -68,7 +78,10 @@ done
 ```
 
 ## Inotify-Script with lz4 compression
-Like the Inotify example, but compress data with lz4 before pushing to destination.
+
+Like the Inotify example, but compress data with lz4 before pushing to
+destination.
+
 ```
 watchnames=''
 [ -d /data/ ] && watchnames="$watchnames /data/"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ do
 done
 ```
 
+## Inotify-Script with lz4 compression
+Like the Inotify example, but compress data with lz4 before pushing to destination.
+```
+watchnames=''
+[ -d /data/ ] && watchnames="$watchnames /data/"
+inotifywait --monitor -e close_write --format %w%f $watchnames | while read FILE
+do
+  echo "$FILE is finished. Moving to data/finished/"
+  lz4 --rm -c9 $FILE > data/finished/$FILE.lz4
+  rclone move /data/finished/ $RCLONE_REMOTE_NAME:RCLONE_REMOTE_PATH/
+done
+```
+
 Endpoints checked:
 - [x] SFTP
 - [X] Onedrive

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Besides `rclone` this container also features `inotify`. Watchpatterns can be us
 are being transfered. This is important so no garbage-data is moved (e.g. traces still beeing captured).
 All inotify-events for a directory `/data/` can be neatly logged using this command:
 ```
-inotifywait -mr --timefmt '%H:%M' --format '%T %w %e %f' /data/"
+inotifywait -mr --timefmt '%H:%M' --format '%T %w %e %f' /data/
 ```
 
 ## Inotify-Script

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker run --rm -it -e RCLONE_CONFIG_SFTP_TYPE=sftp \
 -e RCLONE_CONFIG_SFTP_HOST=host.com \
 -e RCLONE_CONFIG_SFTP_USER=name \
 -e RCLONE_CONFIG_SFTP_PORT=23 \
--e RCLONE_CONFIG_SFTP_PASS=password travelping/rclone:v1.0 touch sftp:path
+-e RCLONE_CONFIG_SFTP_PASS=password travelping/rclone:latest touch sftp:path
 ```
 
 ### Run `rclone` (s3)
@@ -38,7 +38,7 @@ docker run --rm -it -e RCLONE_CONFIG_S3_TYPE: "s3" \
 -e RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "<sensitive>" \
 -e RCLONE_CONFIG_S3_REGION: "s3-<region>" \
 -e RCLONE_CONFIG_S3_ACL: "private" \
-    RCLONE_CONFIG_S3_FORCE_PATH_STYLE: "false" travelping/rclone:v1.0 touch sftp:path
+    RCLONE_CONFIG_S3_FORCE_PATH_STYLE: "false" travelping/rclone:latest touch sftp:path
 ```
 
 ### Run shell

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ do
 done
 ```
 
+## Inotify-Script with zstd compression
+
+Like the Inotify example, but compress data with zstd before pushing to
+destination.  It compresses better than .lz4 but needs more CPU cycles. So,
+pick your poison.
+
+```
+watchnames=''
+[ -d /data/ ] && watchnames="$watchnames /data/"
+inotifywait --monitor -e close_write --format %w%f $watchnames | while read FILE
+do
+  echo "$FILE is finished. Moving to data/finished/"
+  zsdt --rm -19 $FILE -o data/finished/$FILE.zstd
+  rclone move /data/finished/ $RCLONE_REMOTE_NAME:RCLONE_REMOTE_PATH/
+done
+```
+
+
+
 Endpoints checked:
 - [x] SFTP
 - [X] Onedrive

--- a/README.md
+++ b/README.md
@@ -5,10 +5,25 @@ $ docker build --build-arg VERSION=$RCLONE_VERSION -t rclone .
 ```
 
 # Usage
-Besides `rclone` this container also features `inotify`.
+`Rclone` is defined generically through the container environment.
+To find the name of the environment variable, first, take the long option name,
+strip the leading --, change - to _ make upper case and prepend RCLONE_.
+All available endpoints are described in the [official rclone documentation](https://rclone.org/commands/rclone_move/)
+of each command.
 ### Run `rclone` (default entrypoint)
 ```bash
 $ docker run --rm -it travelping/rclone:latest --help
+```
+
+### Run `rclone` (sftp)
+This configuration provides a simple functionality test by enhancing the default entrypoint (`usr/bin/rclone`).
+Running a touch command on the remote path of a sftp server can be done entirely through environment.
+```bash
+docker run --rm -it -e RCLONE_CONFIG_SFTP_TYPE=sftp \
+-e RCLONE_CONFIG_SFTP_HOST=host.com \
+-e RCLONE_CONFIG_SFTP_USER=name \
+-e RCLONE_CONFIG_SFTP_PORT=23 \
+-e RCLONE_CONFIG_SFTP_PASS=mSZyspHocI375S3V7OupBbljCpqSnhD6 travelping/rclone:v1.0 touch sftp:path
 ```
 
 ### Run shell
@@ -16,15 +31,15 @@ $ docker run --rm -it travelping/rclone:latest --help
 $ docker run --rm -it --entrypoint=/bin/sh travelping/rclone:latest
 ```
 
-
-## Debugging
+## Inotify
+Besides `rclone` this container also features `inotify`. Watchpatterns can be used to make sure only finished files
+are being transfered.
 All inotify-events can be neatly logged using this command:
 ```
 inotifywait -mr --timefmt '%H:%M' --format '%T %w %e %f' /data/"
 ```
 
-## Script
-
+## Inotify-Script
 Wating for the `close_write` event, this command only pushes "finished" data to the destination.
 ```
 watchnames=''
@@ -33,11 +48,6 @@ inotifywait --monitor -e close_write --format %w%f $watchnames | while read FILE
 do
   echo "$FILE is finished. Moving to data/finished/"
   mv $FILE/ data/finished/
-  rclone move /data/finished/ onedrive:data/
+  rclone move /data/finished/ sftp:data/
 done
 ```
-
-Endpoints checked:
-- [x] SFTP
-- [X] Onedrive
-- [ ] S3


### PR DESCRIPTION
Upgrade rclone and base image

This commit bumps the packaged rclone version to v1.50.2. The changelog
for this release is available (here)[1]. The major changes (to
rclone-1.49.1) are addressing several memory leaks and more robustness.

This commit also bumps the base image version to Alpine-3.11.3.

In addition, the Dockerfile now uses opencontainers.org labels to
annotate the created container image.

[1]: https://github.com/rclone/rclone/blob/master/docs/content/changelog.md#v1502---2019-11-19